### PR TITLE
Vincent: WebSockets tests

### DIFF
--- a/test/hopjs/serv/aux/wsOpenClient.js
+++ b/test/hopjs/serv/aux/wsOpenClient.js
@@ -1,0 +1,51 @@
+/*=====================================================================*/
+/*    serrano/prgm/project/hop/3.0.x/test/hopjs/serv/aux/wsOpenClient.js*/
+/*    -------------------------------------------------------------    */
+/*    Author      :  Vincent Prunet                                    */
+/*    Creation    :  Thu Sep  17 11:43:00 2015                         */
+/*    Last change :  Tue Sep  15 12:42:26 2015 (serrano)               */
+/*    Copyright   :  2015 Inria                                        */
+/*    -------------------------------------------------------------    */
+/*    simple worker to open/close a WebSocket                          */
+/*=====================================================================*/
+
+/* This worker iterates create/send/receive/close on WebSockets for
+ * <num> times, then post a message to inform the main thread of
+ * completion */
+
+var hop = require( 'hop' );
+var assert = require( 'assert' );
+
+function test( id, num ) {
+   var ws;
+   
+   function loop( num ) {
+      if ( num == 0 ) {
+	 postMessage( id );
+      } else {
+	 console.log( 'client #%s: call #%s', id, num );
+	 ws = new WebSocket( 'ws://localhost:'+ hop.port + '/hop/serv' );
+	 ws.onopen = function() {
+	    ws.send( JSON.stringify( { id: id, num: num } ));
+	 };
+	 ws.onmessage = function( event ) {
+	    var data = JSON.parse( event.data );
+	    assert.equal( id, data.id );
+	    ws.close();
+	 };
+	 ws.onclose = function() {
+	    loop( num - 1 );
+	 };
+      };
+   }
+   loop( num );
+}
+
+/* Protocol with workers launcher */
+onmessage = function( e ) {
+   var id = e.data.clientId;
+   var num = e.data.num;
+   console.log( 'client start', id, num );
+   test( id, num );
+};
+

--- a/test/hopjs/serv/webSocketOpen.js
+++ b/test/hopjs/serv/webSocketOpen.js
@@ -1,0 +1,42 @@
+/*=====================================================================*/
+/*    serrano/prgm/project/hop/3.0.x/test/hopjs/serv/webSocketOpen.js  */
+/*    -------------------------------------------------------------    */
+/*    Author      :  Vincent Prunet                                    */
+/*    Creation    :  Tue Sep  15 11:43:00 2015                         */
+/*    Last change :  Tue Sep  15 12:42:26 2015 (serrano)               */
+/*    Copyright   :  2015 Inria                                        */
+/*    -------------------------------------------------------------    */
+/*    Test repetitive open/close of a WebSocket                        */
+/*=====================================================================*/
+
+var hop = require( 'hop' );
+var runTest = require( './aux/launchWorkers.js' ).runTest;
+var clientModule = require.resolve( './aux/wsOpenClient.js' );
+
+var NUMCLIENTS = 1; // number of concurrent clients
+var NUMCALLS = 1000; // number of service invocations per client
+var TIMEOUT = 10000; //global timeout (test will fail if not completed by then)
+// change TIMEOUT value to match your hardware
+
+// The WebSocket server
+// accepts all connections,
+// echo the received message.
+
+var connections = 0;
+
+var serv = new WebSocketServer( {path: 'serv'} );
+serv.onconnection = function( event ) {
+   connections++;
+   console.log( 'WebSocketServer new connection: %s', connections );
+   var ws = event.value;
+   ws.onmessage = function( event ) {
+      console.log( 'WebSocketServer processing message', event.data );
+      ws.send( event.data );
+   };
+   ws.onclose = function() {
+      connections--;
+      console.log( 'WeSocketServer closing connection: %s', connections );
+   }
+};
+
+runTest( clientModule, NUMCLIENTS, NUMCALLS, TIMEOUT );


### PR DESCRIPTION
Reveals two issues (tested on OS X) :
onclose is never called on the server side.
blocks after a few iterations (seems related to a synchronization
issue: a message  sent from the client just after the WS is open may
not be received on the server.