### PR TITLE
Minor fix when a service is called through a websocket

### DIFF
--- a/share/hop-request.js
+++ b/share/hop-request.js
@@ -649,6 +649,7 @@ HopFrame.prototype.hop_bigloo_serialize = hop_bigloo_serialize_hopframe;
 /*    onPostMessage ...                                                */
 /*---------------------------------------------------------------------*/
 function onPostMessage( e ) {
+   var ws = this;
    if( e.data instanceof ArrayBuffer ) {
       var buf = new Uint8Array( e.data );
 
@@ -701,7 +702,7 @@ function WebSocketPostFrame( frame, succ, fail ) {
       ws.postCount = 0;
       ws.binaryType = "arraybuffer";
 
-      ws.addEventListener( "message", onPostMessage );
+      ws.addEventListener( "message", onPostMessage.bind( ws ) );
       ws.addEventListener( "close", function( e ) {
 	 if( ws.preOpenQueue ) { ws.preOpenQueue.forEach( closeFrame ) }
 	 for( var k in ws.postHandlers ) { closeFrame( ws.postHandlers[ k ] ) }


### PR DESCRIPTION
With the example below, the browser is connected to the `demo` service and return an error via the console : `Cannot read property postHandlers of undefined`

``` js
service demo() {
   return <html>
      <body onload=~{
         var host = "localhost";
         var port = 8080;
         var ws = new WebSocket( "ws://" + host + ":" + port + "/hop/serv" );
         ws.bar = service bar();

         console.log( ws );

         ws.onopen = function() {
            console.log( 'ws.onopen client.js' );
            this.bar( 1 ).post( function( result ) {
               console.log( 'ws foo response:', result );
            }, function( fail ) {
               console.log( 'ws foo fail:', fail );
            } );
         };

         ws.onclose = function( event ) {
            console.error( "ws client websocket closed." );
         };

         ws.onerror = function( err ) {
            console.log( "ws error:", err );
         };
      }>
      </body>
   </html>
}

var serv = new WebSocketServer( { path: "serv" } );

serv.onconnection = function( event ) {
   var ws = event.value;
   var socket = ws.socket;

   console.error( "connection established:", socket );

   ws.onmessage = function( event ) {
      console.log( "server received [%s]", event.data );
   };

   ws.onclose = function( event ) {
      console.log( "client socket closed." );
   };
   ws.send( "something" );
};

service bar( i ) {
   return i + i;
}
```