### PR TITLE
Proposed fix to support multiple listener Monitors

### DIFF
--- a/nodejs/hop.js
+++ b/nodejs/hop.js
@@ -120,7 +120,7 @@ function eventListenerMonitor( ... events ) {
    // Although the two following methods have no free variables, they
    // must be created for each monitor. If they would be shared by
    // all monitors the removeEventListener would not work properly.
-   Object.defineProperty( eventListenerMonitor.prototype, "connectListener", {
+   Object.defineProperty( this, "connectListener", {
       configurable: false, enumerable: false, writable: false,
       value: e => {
 	 if( this.events.indexOf( e.data ) >= 0 ) {
@@ -128,7 +128,7 @@ function eventListenerMonitor( ... events ) {
 	 }
       }
    } );
-   Object.defineProperty( eventListenerMonitor.prototype, "disconnectListener", {
+   Object.defineProperty( this, "disconnectListener", {
       configurable: false, enumerable: false, writable: false,
       value: e => {
 	 if( this.events.indexOf( e.data ) >= 0 ) {
@@ -138,7 +138,7 @@ function eventListenerMonitor( ... events ) {
    } );
 
    events.forEach( this.monitor, this );
-   
+
    return this;
 }
 
@@ -168,7 +168,7 @@ eventListenerMonitor.prototype.addEventListener = function( evname, ltn ) {
       case "newListener":
 	 this.conlisteners.push( ltn );
 	 break;
-	 
+
       case "removeListener":
 	 this.dislisteners.push( ltn );
 	 break;
@@ -180,7 +180,7 @@ eventListenerMonitor.prototype.removeEventListener = function( evname, ltn ) {
       case "newListener":
 	 this.conlisteners.filter( l => l != ltn );
 	 break;
-	 
+
       case "removeListener":
 	 this.dislisteners.filter( l => l != ltn );
 	 break;
@@ -212,4 +212,3 @@ exports.systime = hop.modulesDir + "/systime";
 
 Object.seal( exports );
 Object.freeze( exports );
-


### PR DESCRIPTION
The properties connectListener and disconnectListener must be attached to each Monitor instance, not to their prototype object.