### PR TITLE
Fixed a bug.

### DIFF
--- a/hopscript/regexp.scm
+++ b/hopscript/regexp.scm
@@ -535,6 +535,7 @@
 		     (js-raise-type-error %this "Not a regexp" this)))
 	      0 "ignoreCase"
 	      :prototype (js-undefined))
+      :set (js-undefined)
       :writable #f
       :enumerable #f
       :configurable #t)
@@ -548,6 +549,7 @@
 		     (js-raise-type-error %this "Not a regexp" this)))
 	      0 "multiline"
 	      :prototype (js-undefined))
+      :set (js-undefined)
       :writable #f
       :enumerable #f
       :configurable #t)
@@ -561,6 +563,7 @@
 		     (js-raise-type-error %this "Not a regexp" this)))
 	      0 "global"
 	      :prototype (js-undefined))
+      :set (js-undefined)
       :writable #f
       :enumerable #f
       :configurable #t)
@@ -574,6 +577,7 @@
 		     (js-raise-type-error %this "Not a regexp" this)))
 	      0 "source"
 	      :prototype (js-undefined))
+      :set (js-undefined)
       :writable #f
       :enumerable #f
       :configurable #t)


### PR DESCRIPTION
// RegExp.prototype.{ source, ignoreCase, multiline, global } had a wrong property descriptor,
// which causes an exception in the following code:
var o = {};
var desc = Object.getOwnPropertyDescriptor(RegExp.prototype, "source");
Object.defineProperty(o, "source", desc);
