### PR TITLE
Fixed a semantic bug of JavaScript (8.10.4 FromPropertyDescriptor).

### DIFF
--- a/hopscript/boolean.scm
+++ b/hopscript/boolean.scm
@@ -129,8 +129,7 @@
 ;*    js-valueof ::JsBoolean ...                                       */
 ;*---------------------------------------------------------------------*/
 (define-method (js-valueof this::JsBoolean %this)
-   (with-access::JsBoolean this (val)
-      val))
+   this)
    
 ;*---------------------------------------------------------------------*/
 ;*    init-builtin-boolean-prototype! ...                              */

--- a/hopscript/date.scm
+++ b/hopscript/date.scm
@@ -253,8 +253,8 @@
 	 ;; create a HopScript object
 	 (define (%js-date this . args)
 	    (let ((dt (js-date-construct (js-date-alloc %this js-date))))
-	       (js-call0 %this (js-get dt (& "toString") %this) dt)))
-	 
+	       (js-call0 %this (js-tojsstring dt %this) dt)))
+
 	 (set! js-date
 	    (js-make-function %this %js-date 7 "Date"
 	       :__proto__ js-function-prototype
@@ -1089,7 +1089,21 @@
 				    :month (->fixnum-safe month)
 				    :day (->fixnum-safe date)))
 		       (date->milliseconds val))))
-	     val)))
+	     ;; 1. Let t be the result of LocalTime(this time value); but if this time value is NaN, let t be +0.
+	     (let ((year (js-tonumber year %this))
+		   (month (if (eq? month (js-undefined)) 1 (js-tonumber month %this)))
+		   (date (if (eq? date (js-undefined)) 1 (js-tonumber date %this))))
+		(if (and (flonum? year) (nanfl? year))
+		    (begin
+		       (set! val year)
+		       year)
+		    (begin
+		       (set! val (make-date
+				    :year (->fixnum-safe year)
+				    :month (->fixnum-safe month)
+				    :day (->fixnum-safe date)
+				    :hour 0 :min 0 :sec 0))
+		       (date->milliseconds val)))))))
 
    (js-bind! %this obj (& "setFullYear")
       :value (js-make-function %this date-prototype-setfullyear 3 "setFullYear")

--- a/hopscript/json.scm
+++ b/hopscript/json.scm
@@ -120,7 +120,14 @@
 		       (with-access::JsGlobalObject %this (js-object)
 			  (js-new0 %this js-object)))
       :object-set (lambda (o p val)
-		     (js-put! o (js-toname p %this) val #f %this))
+		     (let* ((name (js-toname p %this))
+			    (desc (instantiate::JsValueDescriptor
+				    (name name)
+				    (value val)
+				    (enumerable #t)
+				    (configurable #t)
+				    (writable #t))))
+			 (js-define-own-property o name desc #f %this)))
       :object-return (lambda (o) o)
       :parse-error (lambda (msg fname loc)
 		      (js-raise-syntax-error %this msg #f
@@ -445,7 +452,14 @@
    (define (default)
       (with-access::JsGlobalObject %this (js-object)
 	 (let ((holder (js-new0 %this js-object)))
-	    (js-put! holder (& "") value #f %this)
+	    (let* ((name (js-toname (& "") %this))
+		   (desc (instantiate::JsValueDescriptor
+		   (name name)
+		   (value value)
+		   (enumerable #t)
+		   (configurable #t)
+		   (writable #t))))
+		(js-define-own-property holder name desc #f %this))
 	    (str (& "") holder '()))))
    
    (cond

--- a/hopscript/object.scm
+++ b/hopscript/object.scm
@@ -616,6 +616,8 @@
       (define (getownpropertydescriptor this o p)
 	 (let* ((o (if (isa? o object)
 		       o
+		       ;; This is not compatible with the recent semantics.
+		       ;; https://www.ecma-international.org/ecma-262/#sec-object.getownpropertydescriptor
 		       (js-cast-object o %this "getOwnPropertyDescriptor")))
 		(desc (js-get-own-property o p %this)))
 	    (js-from-property-descriptor %this o desc o)))

--- a/hopscript/property.scm
+++ b/hopscript/property.scm
@@ -1227,6 +1227,16 @@
 
    (define (js-or x y)
       (if (eq? x (js-undefined)) y x))
+
+   (define (js-put! o::JsObject p v throw %this)
+      (let ((newdesc (instantiate::JsValueDescriptor
+                          (name p)
+                          (value v)
+                          (writable #t)
+                          (enumerable #t)
+                          (configurable #t))))
+;          (js-invalidate-pcaches-pmap! %this p)
+         (js-define-own-property o p newdesc throw %this)))
    
    (define (from-object obj desc)
       ;; proxy getOwnPropertyDescriptor returns regular objects

--- a/hopscript/property.scm
+++ b/hopscript/property.scm
@@ -3044,7 +3044,7 @@
 	  (cond
 	     ((not (js-object-mode-extensible? o))
 	      ;; 3
-	      (reject (format "\"~a\" not extensible" (js-tostring o %this))))
+	      (reject (format "\"~a\" not extensible" (js-typeof o %this))))
 	     (else
 	      ;; 4
 	      (let ((ndesc (cond
@@ -3108,13 +3108,13 @@
 		 ;; 7.a
 		 (reject
 		    (format "\"~a.~a\" configurability mismatch"
-		       (js-tostring o %this) name)))
+		       (js-typeof o %this) name)))
 		((and (boolean? (enumerable desc))
 		      (not (eq? (enumerable current) (enumerable desc))))
 		 ;; 7.b
 		 (reject
 		    (format "\"~a.~a\" enumerability mismatch"
-		       (js-tostring o %this) name)))))
+		       (js-typeof o %this) name)))))
 	  (unless rejected
 	     (cond
 		((js-is-generic-descriptor? desc)
@@ -3128,7 +3128,7 @@
 		     ;; 9.a
 		     (reject
 			(format "\"~a.~a\" configurability mismatch"
-			   (js-tostring o %this) name)))
+			   (js-typeof o %this) name)))
 		    ((isa? current JsDataDescriptor)
 		     ;; 9.b
 		     (when (isa? desc JsAccessorDescriptor)
@@ -3153,7 +3153,7 @@
 			 ;; 10.a.i
 			 (reject
 			    (format "\"~a.~a\" read-only"
-			       (js-tostring o %this) name)))
+			       (js-typeof o %this) name)))
 			((eq? (writable current) #f)
 			 ;; 10.a.ii
 			 (if (and (isa? desc JsValueDescriptor)
@@ -3161,7 +3161,7 @@
 				  (not (same-value (value desc) (value current))))
 			     (reject
 				(format "\"~a.~a\" value mismatch"
-				   (js-tostring o %this) name))
+				   (js-typeof o %this) name))
 			     #t))
 			(else
 			 (propagate-data-descriptor! current desc)))
@@ -3174,12 +3174,12 @@
 			((and (set desc) (not (equal? (set current) (set desc))))
 			 (reject
 			    (format "\"~a.~a\" setter mismatch"
-			       (js-tostring o %this) name)))
+			       (js-typeof o %this) name)))
 			((and (get desc)
 			      (not (equal? (get current) (get desc))))
 			 (reject
 			    (format "\"~a.~a\" getter mismatch"
-			       (js-tostring o %this) name)))
+			       (js-typeof o %this) name)))
 			(else
 			 (propagate-accessor-descriptor! current desc)))
 		     (propagate-accessor-descriptor! current desc)))

--- a/hopscript/public.scm
+++ b/hopscript/public.scm
@@ -1723,8 +1723,7 @@
        (with-handler
 	  (lambda (e)
 	     (js-jsstring->string (js-typeof obj %this)))
-	  (js-jsstring->string
-	     (js-call0 %this (js-get obj (& "toString") %this) obj))))
+	  (js-jsstring->string (js-typeof obj))))
       ((eq? obj #unspecified)
        "undefined")
       ((eq? obj #f)
@@ -1736,7 +1735,7 @@
       ((or (js-number? obj) (int32? obj) (uint32? obj))
        (number->string obj))
       (else
-       (js-tostring obj %this))))
+       (js-jsstring->string (js-typeof obj)))))
 
 ;*---------------------------------------------------------------------*/
 ;*    js-raise-type-error ...                                          */

--- a/hopscript/public.scm
+++ b/hopscript/public.scm
@@ -318,8 +318,8 @@
 ;*    Used by functions that are not allowed to be used in NEW expr.   */
 ;*---------------------------------------------------------------------*/
 (define (js-not-a-constructor-alloc %this ctor::JsFunction)
-   (let ((name (js-tostring (js-get ctor (& "name") %this) %this)))
-      (js-raise-type-error %this "~s not a constructor" name)))
+   (with-access::JsFunction ctor (procedure)
+      (js-raise-type-error %this "~s not a constructor" procedure)))
 
 ;*---------------------------------------------------------------------*/
 ;*    js-function-set-constrmap! ...                                   */

--- a/hopscript/types.scm
+++ b/hopscript/types.scm
@@ -868,6 +868,19 @@
 	 enumerable)))
 
 ;*---------------------------------------------------------------------*/
+;*    object-print ::JsWrapperDescriptor ...                          */
+;*---------------------------------------------------------------------*/
+(define-method (object-print p::JsWrapperDescriptor port pslot::procedure)
+   (with-access::JsWrapperDescriptor p (name configurable enumerable writable)
+      (fprintf port
+	 "#|~s name=~a configurable=~a enumerable=~a writable=~a|"
+	 (class-name (object-class p))
+	 name
+	 configurable
+	 enumerable
+	 writable)))
+
+;*---------------------------------------------------------------------*/
 ;*    object-print ::JsValueDescriptor ...                             */
 ;*---------------------------------------------------------------------*/
 (define-method (object-print p::JsValueDescriptor port pslot::procedure)


### PR DESCRIPTION
 I found a bug in JavaScript semantics implemented in hop.

* 8.10.4 FromPropertyDescriptor
 It uses [[DefineOwnProperty]] when it creates fields {value, writable, get, set, enumerable, configurable}.
 But, in hop implementation, it uses [[Put]] semantics.
 Because of this difference, this instruction implicitly accesses fields in its prototype chain.

 Simply, the following code would make difference:
```JavaScript
Object.defineProperty(Object.prototype, "value", {set: function(x) { console.log("hacked! "); }})
var o = {x:10};
Object.getOwnPropertyDescriptor(o, "x”)
```
 In the case of nodejs or browser, it returns nothing.
 But, the program compiled by hopjs displays “hacked!” message.

