### PR TITLE
Fix a bug in json generation.

### DIFF
--- a/js2scheme/stage.scm
+++ b/js2scheme/stage.scm
@@ -142,7 +142,8 @@
 				    (when v
 				       (fprintf op "\"~a\": ~a" (car args) v))
 				    (when (pair? (cddr args))
-				       (display ", " op)
+				       (when v
+                                          (display ", " op))
 				       (loop (cddr args))))))
 			   (display "}}" op))))))))
 	 


### PR DESCRIPTION
The original code adds an extra "," string when `when v` evaluates to false, and it generates a malformed JSON.